### PR TITLE
Fix SDL2 casing

### DIFF
--- a/pages/Compiling_on_Windows_using_MSYS2.md
+++ b/pages/Compiling_on_Windows_using_MSYS2.md
@@ -19,7 +19,7 @@ The terminal will then ask you to close it when done, proceed with doing so and 
 First install all the necessary dependencies:
 
 ```bash
-pacman -S git mingw-w64-clang-x86_64-{clang,cmake,ninja,curl-winssl,libpng,libjpeg-turbo,freetype,libogg,libvorbis,sqlite3,openal,zstd,gettext,luajit,sdl2}
+pacman -S git mingw-w64-clang-x86_64-{clang,cmake,ninja,curl-winssl,libpng,libjpeg-turbo,freetype,libogg,libvorbis,sqlite3,openal,zstd,gettext,luajit,SDL2}
 ```
 
 Navigate to some folder where you want to clone the Minetest repository. To get out of MSYS' home folder and into your regular users folder, you would want to enter something like this:


### PR DESCRIPTION
Fixes this:

```
error: target not found: mingw-w64-clang-x86_64-sdl2
```

https://packages.msys2.org/base/mingw-w64-SDL2

Thanks for writing this, btw. It's lot less painful than the MSVC way.